### PR TITLE
`PartialTrie` default

### DIFF
--- a/src/partial_trie.rs
+++ b/src/partial_trie.rs
@@ -75,6 +75,12 @@ impl PartialEq for PartialTrie {
     }
 }
 
+impl Default for PartialTrie {
+    fn default() -> Self {
+        Self::Empty
+    }
+}
+
 #[derive(Copy, Clone, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 /// A sequence of nibbles.
 pub struct Nibbles {


### PR DESCRIPTION
This would be convenient in our EVM code, and I think it's idiomatic for a data structure's `default()` to return an empty structure.