### PR TITLE
Added tooling for trie stats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ keccak-hash = "0.10.0"
 parking_lot = { version = "0.12.1", features = ["serde"] }
 thiserror = "1.0.40"
 log = "0.4.17"
+num = { version = "0.4.1", optional = true }
 num-traits = "0.2.15"
 uint = "0.9.5"
 rlp = "0.5.2"
@@ -39,7 +40,7 @@ serde_json = "1.0.96"
 
 [features]
 default = ["trie_debug"]
-trie_debug = []
+trie_debug = ["num"]
 
 [lib]
 doc-scrape-examples = true

--- a/src/debug_tools/mod.rs
+++ b/src/debug_tools/mod.rs
@@ -4,3 +4,4 @@
 pub mod common;
 pub mod diff;
 pub mod query;
+pub mod stats;

--- a/src/debug_tools/stats.rs
+++ b/src/debug_tools/stats.rs
@@ -1,0 +1,112 @@
+use crate::partial_trie::{Node, PartialTrie};
+
+#[derive(Debug, Default)]
+pub struct TrieStats {
+    pub counts: NodeCounts,
+    pub depth_stats: DepthStats,
+}
+
+#[derive(Debug, Default)]
+pub struct NodeCounts {
+    empty: usize,
+    hash: usize,
+    branch: usize,
+    extension: usize,
+    leaf: usize,
+}
+
+impl NodeCounts {
+    pub fn total_nodes(&self) -> usize {
+        self.empty + self.total_node_non_empty()
+    }
+
+    pub fn total_node_non_empty(&self) -> usize {
+        self.branch + self.extension + self.hash_and_leaf_node_count()
+    }
+
+    pub fn hash_and_leaf_node_count(&self) -> usize {
+        self.hash + self.leaf
+    }
+
+    pub fn compare(&self, _other: &Self) -> TrieComparison {
+        todo!()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct TrieComparison {}
+
+#[derive(Debug, Default)]
+struct CurrTrackingState {
+    counts: NodeCounts,
+    leaf_and_hash_depth_sum: u64,
+    lowest_depth: usize,
+}
+
+impl CurrTrackingState {
+    fn update_lowest_depth_if_larger(&mut self, curr_depth: usize) {
+        if self.lowest_depth > curr_depth {
+            self.lowest_depth = curr_depth;
+        }
+    }
+}
+
+/// Depth in terms of node depth (not key length).
+#[derive(Debug, Default)]
+pub struct DepthStats {
+    pub lowest_depth: usize,
+    pub avg_leaf_depth: f32,
+}
+
+pub fn get_trie_stats<T: PartialTrie>(trie: &T) -> TrieStats {
+    let mut state = CurrTrackingState::default();
+
+    get_trie_stats_rec(trie, &mut state, 0);
+
+    let depth_stats = DepthStats {
+        lowest_depth: state.lowest_depth,
+        avg_leaf_depth: state.leaf_and_hash_depth_sum as f32
+            / state.counts.hash_and_leaf_node_count() as f32,
+    };
+
+    TrieStats {
+        counts: state.counts,
+        depth_stats,
+    }
+}
+
+fn get_trie_stats_rec<T: PartialTrie>(
+    node: &Node<T>,
+    state: &mut CurrTrackingState,
+    curr_depth: usize,
+) {
+    match node {
+        Node::Empty => {
+            state.counts.empty += 1;
+        }
+        Node::Hash(_) => {
+            state.counts.hash += 1;
+            state.leaf_and_hash_depth_sum += curr_depth as u64;
+            state.update_lowest_depth_if_larger(curr_depth);
+        }
+        Node::Branch { children, value: _ } => {
+            state.counts.branch += 1;
+
+            for c in children {
+                get_trie_stats_rec(c, state, curr_depth + 1);
+            }
+        }
+        Node::Extension { nibbles: _, child } => {
+            state.counts.extension += 1;
+            get_trie_stats_rec(child, state, curr_depth + 1);
+        }
+        Node::Leaf {
+            nibbles: _,
+            value: _,
+        } => {
+            state.counts.leaf += 1;
+            state.leaf_and_hash_depth_sum += curr_depth as u64;
+            state.update_lowest_depth_if_larger(curr_depth);
+        }
+    }
+}

--- a/src/debug_tools/stats.rs
+++ b/src/debug_tools/stats.rs
@@ -1,6 +1,6 @@
-//! Simple stat tooling to extract stats from tries.
+//! Simple tooling to extract stats from tries.
 //!
-//! This is particularly useful when comparing a "base" trie against a sub-trie
+//! This is particularly useful when comparing a "base" trie against a sub-trie (hashed out trie)
 //! created from it.
 
 use std::fmt::{self, Display};
@@ -110,8 +110,6 @@ pub struct TrieComparison {
 }
 
 impl Display for TrieComparison {
-    // Pretty debug is pretty good by default If we want something better, we can do
-    // our own.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Node comparison: {}", self.node_comp)?;
         writeln!(f, "Depth comparison: {}", self.depth_comp)
@@ -155,7 +153,7 @@ impl Display for DepthComparison {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Lowest depth: {}", self.lowest_depth_rat)?;
         writeln!(f, "Avg leaf depth: {}", self.avg_leaf_depth_rat)?;
-        writeln!(f, "Avg hah depth: {}", self.avg_hash_depth_rat)
+        writeln!(f, "Avg hash depth: {}", self.avg_hash_depth_rat)
     }
 }
 
@@ -179,7 +177,7 @@ impl<T: Display + ToPrimitive> Display for RatioStat<T> {
 }
 
 impl<T: ToPrimitive> RatioStat<T> {
-    /// `new` doesn't do any logic, but this will reduce a lot of line lengths
+    /// `new` doesn't have any logic, but this will reduce a lot of line lengths
     /// since this is called so many times.
     fn new(a: T, b: T) -> Self {
         Self { a, b }

--- a/src/debug_tools/stats.rs
+++ b/src/debug_tools/stats.rs
@@ -1,7 +1,7 @@
 //! Simple tooling to extract stats from tries.
 //!
-//! This is particularly useful when comparing a "base" trie against a sub-trie (hashed out trie)
-//! created from it.
+//! This is particularly useful when comparing a "base" trie against a sub-trie
+//! (hashed out trie) created from it.
 
 use std::fmt::{self, Display};
 
@@ -318,8 +318,9 @@ mod tests {
         assert_eq!(stats.counts.hash, 0);
         assert_eq!(stats.counts.branch, 4);
         assert_eq!(stats.counts.extension, 2);
-        assert_eq!(stats.counts.empty, 57); // (n_branch * 4) - n_leaf -
-                                            // (n_branch - 1)
+
+        // empty = (n_branch * 4) - n_leaf - (n_branch - 1)
+        assert_eq!(stats.counts.empty, 57);
     }
 
     // TODO: Low-priority. Finish later.
@@ -331,30 +332,30 @@ mod tests {
 
     #[test]
     fn massive_leaf_trie_has_correct_leaf_node_stats() {
-        let entries = generate_n_random_fixed_trie_value_entries(MASSIVE_TRIE_SIZE, 9522);
-        let trie = HashedPartialTrie::from_iter(entries);
-
-        let stats = get_trie_stats(&trie);
-
-        assert_eq!(stats.counts.leaf, MASSIVE_TRIE_SIZE);
-        assert_eq!(stats.counts.hash, 0);
+        create_trie_and_stats_from_entries_and_assert(MASSIVE_TRIE_SIZE, 0, 9522);
     }
 
     #[test]
     fn massive_hash_trie_has_correct_hash_node_stats() {
-        let entries = generate_n_random_fixed_trie_hash_entries(MASSIVE_TRIE_SIZE, 9855);
-        let trie = HashedPartialTrie::from_iter(entries);
-
-        let stats = get_trie_stats(&trie);
-
-        assert_eq!(stats.counts.hash, MASSIVE_TRIE_SIZE);
-        assert_eq!(stats.counts.leaf, 0);
+        create_trie_and_stats_from_entries_and_assert(0, MASSIVE_TRIE_SIZE, 9855);
     }
 
     #[test]
     fn massive_mixed_trie_has_correct_hash_node_stats() {
-        let val_entries = generate_n_random_fixed_trie_value_entries(MASSIVE_TRIE_SIZE / 2, 1992);
-        let hash_entries = generate_n_random_fixed_trie_hash_entries(MASSIVE_TRIE_SIZE / 2, 404);
+        create_trie_and_stats_from_entries_and_assert(
+            MASSIVE_TRIE_SIZE / 2,
+            MASSIVE_TRIE_SIZE / 2,
+            1992,
+        );
+    }
+
+    fn create_trie_and_stats_from_entries_and_assert(
+        n_leaf_nodes: usize,
+        n_hash_nodes: usize,
+        seed: u64,
+    ) {
+        let val_entries = generate_n_random_fixed_trie_value_entries(n_leaf_nodes, seed);
+        let hash_entries = generate_n_random_fixed_trie_hash_entries(n_hash_nodes, seed + 1);
 
         let mut trie = HashedPartialTrie::default();
         trie.extend(val_entries);
@@ -362,8 +363,8 @@ mod tests {
 
         let stats = get_trie_stats(&trie);
 
-        assert_eq!(stats.counts.leaf, MASSIVE_TRIE_SIZE / 2);
-        assert_eq!(stats.counts.hash, MASSIVE_TRIE_SIZE / 2);
+        assert_eq!(stats.counts.leaf, n_leaf_nodes);
+        assert_eq!(stats.counts.hash, n_hash_nodes);
     }
 
     // TODO: Low-priority. Finish later.

--- a/src/debug_tools/stats.rs
+++ b/src/debug_tools/stats.rs
@@ -1,3 +1,8 @@
+//! Simple stat tooling to extract stats from tries.
+//!
+//! This is particularly useful when comparing a "base" trie against a sub-trie
+//! created from it.
+
 use std::fmt::{self, Display};
 
 use crate::partial_trie::{Node, PartialTrie};
@@ -32,13 +37,14 @@ impl TrieStats {
     }
 }
 
+/// Total node counts for a trie.
 #[derive(Debug, Default)]
 pub struct NodeCounts {
-    empty: usize,
-    hash: usize,
-    branch: usize,
-    extension: usize,
-    leaf: usize,
+    pub empty: usize,
+    pub hash: usize,
+    pub branch: usize,
+    pub extension: usize,
+    pub leaf: usize,
 }
 
 impl Display for NodeCounts {
@@ -80,10 +86,11 @@ impl NodeCounts {
     }
 }
 
+/// Information on the comparison between two tries.
 #[derive(Debug)]
 pub struct TrieComparison {
-    node_comp: NodeComparison,
-    depth_comp: DepthComparison,
+    pub node_comp: NodeComparison,
+    pub depth_comp: DepthComparison,
 }
 
 impl Display for TrieComparison {
@@ -122,9 +129,9 @@ impl Display for NodeComparison {
 }
 
 #[derive(Debug)]
-struct DepthComparison {
-    a: DepthStats,
-    b: DepthStats,
+pub struct DepthComparison {
+    pub a: DepthStats,
+    pub b: DepthStats,
 }
 
 impl Display for DepthComparison {
@@ -145,6 +152,7 @@ impl DepthComparison {
     }
 }
 
+/// Type to hold (and compare) a given variable from two different tries.s
 #[derive(Debug)]
 pub struct RatioStat {
     pub a: usize,
@@ -158,8 +166,8 @@ impl Display for RatioStat {
 }
 
 impl RatioStat {
-    /// `new` doesn't do any logic, but this will reduce the line since since
-    /// this is called so many times.
+    /// `new` doesn't do any logic, but this will reduce a lot of line lengths
+    /// since this is called so many times.
     fn new(a: usize, b: usize) -> Self {
         Self { a, b }
     }
@@ -169,9 +177,13 @@ impl RatioStat {
     }
 }
 
+/// "Raw" state that is mutated as we traverse down the trie. Is processed into
+/// a more useful format later on.
 #[derive(Debug, Default)]
 struct CurrTrackingState {
     counts: NodeCounts,
+
+    // The "*_sum" variables are just accumulators that we process later to get average depths.
     leaf_depth_sum: u64,
     hash_depth_sum: u64,
     lowest_depth: usize,

--- a/src/debug_tools/stats.rs
+++ b/src/debug_tools/stats.rs
@@ -69,7 +69,7 @@ impl NodeCounts {
         tot_count: usize,
     ) -> fmt::Result {
         let perc = (count as f32 / tot_count as f32) * 100.0;
-        writeln!(f, "{}: {} ({:.3}%)", node_t_name, count, perc)
+        writeln!(f, "{}: {} ({:.2}%)", node_t_name, count, perc)
     }
 }
 

--- a/src/debug_tools/stats.rs
+++ b/src/debug_tools/stats.rs
@@ -1,9 +1,35 @@
+use std::fmt::{self, Display};
+
 use crate::partial_trie::{Node, PartialTrie};
 
 #[derive(Debug, Default)]
 pub struct TrieStats {
+    pub name: Option<String>,
     pub counts: NodeCounts,
     pub depth_stats: DepthStats,
+}
+
+impl Display for TrieStats {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Trie Stats:")?;
+
+        match self.name.as_ref() {
+            Some(name) => writeln!(f, " ({})", name)?,
+            None => writeln!(f)?,
+        }
+
+        writeln!(f, "Counts: {}", self.counts)?;
+        writeln!(f, "Depth stats: {}", self.depth_stats)
+    }
+}
+
+impl TrieStats {
+    pub fn compare(&self, other: &Self) -> TrieComparison {
+        TrieComparison {
+            node_comp: self.counts.compare(&other.counts),
+            depth_comp: self.depth_stats.compare(&other.depth_stats),
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -13,6 +39,16 @@ pub struct NodeCounts {
     branch: usize,
     extension: usize,
     leaf: usize,
+}
+
+impl Display for NodeCounts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Empty: {}", self.empty)?;
+        writeln!(f, "Hash: {}", self.hash)?;
+        writeln!(f, "Branch: {}", self.branch)?;
+        writeln!(f, "Extension: {}", self.extension)?;
+        writeln!(f, "Leaf: {}", self.leaf)
+    }
 }
 
 impl NodeCounts {
@@ -28,18 +64,116 @@ impl NodeCounts {
         self.hash + self.leaf
     }
 
-    pub fn compare(&self, _other: &Self) -> TrieComparison {
-        todo!()
+    pub fn compare(&self, other: &Self) -> NodeComparison {
+        NodeComparison {
+            tot_node_rat: RatioStat::new(self.total_nodes(), other.total_nodes()),
+            non_empty_rat: RatioStat::new(
+                self.total_node_non_empty(),
+                other.total_node_non_empty(),
+            ),
+            empty_rat: RatioStat::new(self.empty, other.empty),
+            hash_rat: RatioStat::new(self.hash, other.hash),
+            branch_rat: RatioStat::new(self.branch, other.branch),
+            extension_rat: RatioStat::new(self.extension, other.extension),
+            leaf_rat: RatioStat::new(self.leaf, other.leaf),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TrieComparison {
+    node_comp: NodeComparison,
+    depth_comp: DepthComparison,
+}
+
+impl Display for TrieComparison {
+    // Pretty debug is pretty good by default If we want something better, we can do
+    // our own.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Node comparison: {}", self.node_comp)?;
+        writeln!(f, "Depth comparison: {}", self.depth_comp)
+    }
+}
+
+// TODO: Consider computing these values lazily?
+#[derive(Debug)]
+pub struct NodeComparison {
+    pub tot_node_rat: RatioStat,
+    pub non_empty_rat: RatioStat,
+
+    pub empty_rat: RatioStat,
+    pub hash_rat: RatioStat,
+    pub branch_rat: RatioStat,
+    pub extension_rat: RatioStat,
+    pub leaf_rat: RatioStat,
+}
+
+impl Display for NodeComparison {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Total nodes: {}", self.tot_node_rat)?;
+        writeln!(f, "Non-empty: {}", self.non_empty_rat)?;
+
+        writeln!(f, "Total empty: {}", self.empty_rat)?;
+        writeln!(f, "Total hash: {}", self.hash_rat)?;
+        writeln!(f, "Total branch: {}", self.branch_rat)?;
+        writeln!(f, "Total extension: {}", self.extension_rat)?;
+        writeln!(f, "Total leaf: {}", self.leaf_rat)
+    }
+}
+
+#[derive(Debug)]
+struct DepthComparison {
+    a: DepthStats,
+    b: DepthStats,
+}
+
+impl Display for DepthComparison {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Self::write_depth_stats_and_header(f, &self.a, "a")?;
+        Self::write_depth_stats_and_header(f, &self.b, "b")
+    }
+}
+
+impl DepthComparison {
+    fn write_depth_stats_and_header(
+        f: &mut fmt::Formatter<'_>,
+        stats: &DepthStats,
+        trie_str: &str,
+    ) -> fmt::Result {
+        writeln!(f, "Depth stats for {}:", trie_str)?;
+        stats.fmt(f)
+    }
+}
+
+#[derive(Debug)]
+pub struct RatioStat {
+    pub a: usize,
+    pub b: usize,
+}
+
+impl Display for RatioStat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} / {} ({}%)", self.a, self.b, self.get_a_over_b_perc())
+    }
+}
+
+impl RatioStat {
+    /// `new` doesn't do any logic, but this will reduce the line since since
+    /// this is called so many times.
+    fn new(a: usize, b: usize) -> Self {
+        Self { a, b }
+    }
+
+    fn get_a_over_b_perc(&self) -> f32 {
+        (self.a as f32 / self.b as f32) * 100.0
     }
 }
 
 #[derive(Debug, Default)]
-pub struct TrieComparison {}
-
-#[derive(Debug, Default)]
 struct CurrTrackingState {
     counts: NodeCounts,
-    leaf_and_hash_depth_sum: u64,
+    leaf_depth_sum: u64,
+    hash_depth_sum: u64,
     lowest_depth: usize,
 }
 
@@ -52,24 +186,51 @@ impl CurrTrackingState {
 }
 
 /// Depth in terms of node depth (not key length).
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct DepthStats {
     pub lowest_depth: usize,
     pub avg_leaf_depth: f32,
+    pub avg_hash_depth: f32,
+}
+
+impl Display for DepthStats {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Lowest depth: {}", self.lowest_depth)?;
+        writeln!(f, "Average leaf depth: {}", self.avg_leaf_depth)?;
+        writeln!(f, "Average hash depth: {}", self.avg_hash_depth)
+    }
+}
+
+impl DepthStats {
+    fn compare(&self, other: &Self) -> DepthComparison {
+        DepthComparison {
+            a: self.clone(),
+            b: other.clone(),
+        }
+    }
 }
 
 pub fn get_trie_stats<T: PartialTrie>(trie: &T) -> TrieStats {
+    get_trie_stats_common(trie, None)
+}
+
+pub fn get_trie_stats_with_name<T: PartialTrie>(trie: &T, name: String) -> TrieStats {
+    get_trie_stats_common(trie, Some(name))
+}
+
+fn get_trie_stats_common<T: PartialTrie>(trie: &T, name: Option<String>) -> TrieStats {
     let mut state = CurrTrackingState::default();
 
     get_trie_stats_rec(trie, &mut state, 0);
 
     let depth_stats = DepthStats {
         lowest_depth: state.lowest_depth,
-        avg_leaf_depth: state.leaf_and_hash_depth_sum as f32
-            / state.counts.hash_and_leaf_node_count() as f32,
+        avg_leaf_depth: state.leaf_depth_sum as f32 / state.counts.leaf as f32,
+        avg_hash_depth: state.hash_depth_sum as f32 / state.counts.hash as f32,
     };
 
     TrieStats {
+        name,
         counts: state.counts,
         depth_stats,
     }
@@ -86,7 +247,7 @@ fn get_trie_stats_rec<T: PartialTrie>(
         }
         Node::Hash(_) => {
             state.counts.hash += 1;
-            state.leaf_and_hash_depth_sum += curr_depth as u64;
+            state.hash_depth_sum += curr_depth as u64;
             state.update_lowest_depth_if_larger(curr_depth);
         }
         Node::Branch { children, value: _ } => {
@@ -105,7 +266,7 @@ fn get_trie_stats_rec<T: PartialTrie>(
             value: _,
         } => {
             state.counts.leaf += 1;
-            state.leaf_and_hash_depth_sum += curr_depth as u64;
+            state.leaf_depth_sum += curr_depth as u64;
             state.update_lowest_depth_if_larger(curr_depth);
         }
     }

--- a/src/debug_tools/stats.rs
+++ b/src/debug_tools/stats.rs
@@ -271,3 +271,81 @@ fn get_trie_stats_rec<T: PartialTrie>(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::get_trie_stats;
+    use crate::{
+        partial_trie::{HashedPartialTrie, PartialTrie},
+        testing_utils::{
+            generate_n_random_fixed_trie_hash_entries, generate_n_random_fixed_trie_value_entries,
+            handmade_trie_1,
+        },
+    };
+
+    const MASSIVE_TRIE_SIZE: usize = 100_000;
+
+    #[test]
+    fn hand_made_trie_has_correct_node_stats() {
+        let (trie, _) = handmade_trie_1();
+        let stats = get_trie_stats(&trie);
+
+        assert_eq!(stats.counts.leaf, 4);
+        assert_eq!(stats.counts.hash, 0);
+        assert_eq!(stats.counts.branch, 4);
+        assert_eq!(stats.counts.extension, 2);
+        assert_eq!(stats.counts.empty, 57); // (n_branch * 4) - n_leaf -
+                                            // (n_branch - 1)
+    }
+
+    // TODO: Low-priority. Finish later.
+    #[test]
+    #[ignore]
+    fn perfectly_balanced_trie_has_correct_node_stats() {
+        todo!()
+    }
+
+    #[test]
+    fn massive_leaf_trie_has_correct_leaf_node_stats() {
+        let entries = generate_n_random_fixed_trie_value_entries(MASSIVE_TRIE_SIZE, 9522);
+        let trie = HashedPartialTrie::from_iter(entries);
+
+        let stats = get_trie_stats(&trie);
+
+        assert_eq!(stats.counts.leaf, MASSIVE_TRIE_SIZE);
+        assert_eq!(stats.counts.hash, 0);
+    }
+
+    #[test]
+    fn massive_hash_trie_has_correct_hash_node_stats() {
+        let entries = generate_n_random_fixed_trie_hash_entries(MASSIVE_TRIE_SIZE, 9855);
+        let trie = HashedPartialTrie::from_iter(entries);
+
+        let stats = get_trie_stats(&trie);
+
+        assert_eq!(stats.counts.hash, MASSIVE_TRIE_SIZE);
+        assert_eq!(stats.counts.leaf, 0);
+    }
+
+    #[test]
+    fn massive_mixed_trie_has_correct_hash_node_stats() {
+        let val_entries = generate_n_random_fixed_trie_value_entries(MASSIVE_TRIE_SIZE / 2, 1992);
+        let hash_entries = generate_n_random_fixed_trie_hash_entries(MASSIVE_TRIE_SIZE / 2, 404);
+
+        let mut trie = HashedPartialTrie::default();
+        trie.extend(val_entries);
+        trie.extend(hash_entries);
+
+        let stats = get_trie_stats(&trie);
+
+        assert_eq!(stats.counts.leaf, MASSIVE_TRIE_SIZE / 2);
+        assert_eq!(stats.counts.hash, MASSIVE_TRIE_SIZE / 2);
+    }
+
+    // TODO: Low-priority. Finish later.
+    #[test]
+    #[ignore]
+    fn depth_stats_work() {
+        todo!()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,4 +23,4 @@ mod utils;
 pub mod debug_tools;
 
 #[cfg(test)]
-mod testing_utils;
+pub(crate) mod testing_utils;

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -607,6 +607,9 @@ impl Nibbles {
         let hex_string_raw = hex_encode_f(&byte_buf[(64 - count_bytes)..64]);
         let hex_char_iter_raw = hex_string_raw.chars();
 
+
+            // We need this skip to make both match arms have the same type.
+            #[allow(clippy::iter_skip_zero)]
         let mut hex_string = String::from("0x");
         match is_even(self.count) {
             false => hex_string.extend(hex_char_iter_raw.skip(1)),

--- a/src/nibbles.rs
+++ b/src/nibbles.rs
@@ -607,9 +607,8 @@ impl Nibbles {
         let hex_string_raw = hex_encode_f(&byte_buf[(64 - count_bytes)..64]);
         let hex_char_iter_raw = hex_string_raw.chars();
 
-
-            // We need this skip to make both match arms have the same type.
-            #[allow(clippy::iter_skip_zero)]
+        // We need this skip to make both match arms have the same type.
+        #[allow(clippy::iter_skip_zero)]
         let mut hex_string = String::from("0x");
         match is_even(self.count) {
             false => hex_string.extend(hex_char_iter_raw.skip(1)),

--- a/src/testing_utils.rs
+++ b/src/testing_utils.rs
@@ -137,16 +137,6 @@ pub(crate) fn generate_n_hash_nodes_entries_for_empty_slots_in_trie<N: PartialTr
         .collect()
 }
 
-pub(crate) fn create_trie_with_random_variable_key_entries<T: PartialTrie>(
-    n: usize,
-    seed: u64,
-) -> T {
-    let mut trie = T::default();
-    trie.extend(generate_n_random_variable_trie_value_entries(n, seed));
-
-    trie
-}
-
 fn gen_fixed_nibbles(rng: &mut StdRng) -> Nibbles {
     let mut k_bytes = [0; 4];
     k_bytes[0..3].copy_from_slice(rng.gen::<[u64; 3]>().as_slice());

--- a/src/testing_utils.rs
+++ b/src/testing_utils.rs
@@ -184,8 +184,7 @@ pub(crate) fn unwrap_iter_item_to_val(item: ValOrHash) -> Vec<u8> {
 fn gen_rand_u256_bytes(rng: &mut StdRng) -> Vec<u8> {
     let num_bytes = 256 / 8;
 
-    let mut buf = Vec::with_capacity(num_bytes);
-    buf.resize(num_bytes, 0);
+    let mut buf = vec![0; num_bytes];
     rng.fill_bytes(&mut buf);
 
     buf

--- a/src/testing_utils.rs
+++ b/src/testing_utils.rs
@@ -5,11 +5,11 @@ use std::{
 
 use ethereum_types::{H256, U256, U512};
 use log::info;
-use rand::{rngs::StdRng, seq::IteratorRandom, Rng, SeedableRng};
+use rand::{rngs::StdRng, seq::IteratorRandom, Rng, RngCore, SeedableRng};
 
 use crate::{
     nibbles::Nibbles,
-    partial_trie::{Node, PartialTrie},
+    partial_trie::{HashedPartialTrie, Node, PartialTrie},
     trie_ops::ValOrHash,
     utils::is_even,
 };
@@ -20,8 +20,11 @@ use crate::{
 /// chances of these collisions occurring.
 const MIN_BYTES_FOR_VAR_KEY: usize = 5;
 
+pub(crate) type TrieType = HashedPartialTrie;
+
 pub(crate) type TestInsertValEntry = (Nibbles, Vec<u8>);
 pub(crate) type TestInsertHashEntry = (Nibbles, H256);
+type TestInsertEntry<T> = (Nibbles, T);
 
 // Don't want this exposed publicly, but it is useful for testing.
 impl From<i32> for Nibbles {
@@ -70,34 +73,51 @@ where
     (k.into(), vec![v])
 }
 
-pub(crate) fn generate_n_random_fixed_trie_entries(
+pub(crate) fn generate_n_random_fixed_trie_value_entries(
     n: usize,
     seed: u64,
 ) -> impl Iterator<Item = TestInsertValEntry> {
-    gen_n_random_trie_entries_common(n, seed, gen_fixed_nibbles)
+    gen_n_random_trie_value_entries_common(n, seed, gen_fixed_nibbles, gen_rand_u256_bytes)
 }
 
-pub(crate) fn generate_n_random_variable_keys(
+pub(crate) fn generate_n_random_fixed_trie_hash_entries(
     n: usize,
     seed: u64,
-) -> impl Iterator<Item = TestInsertValEntry> {
-    gen_n_random_trie_entries_common(n, seed, gen_variable_nibbles)
+) -> impl Iterator<Item = TestInsertHashEntry> {
+    gen_n_random_trie_value_entries_common(n, seed, gen_fixed_nibbles, |_| H256::random())
 }
 
-pub(crate) fn generate_n_random_fixed_even_nibble_padded_trie_entries(
+pub(crate) fn generate_n_random_variable_trie_value_entries(
     n: usize,
     seed: u64,
 ) -> impl Iterator<Item = TestInsertValEntry> {
-    gen_n_random_trie_entries_common(n, seed, gen_variable_nibbles_even_padded_nibbles)
+    gen_n_random_trie_value_entries_common(n, seed, gen_variable_nibbles, gen_rand_u256_bytes)
 }
 
-fn gen_n_random_trie_entries_common<F: Fn(&mut StdRng) -> Nibbles>(
+pub(crate) fn generate_n_random_fixed_even_nibble_padded_trie_value_entries(
     n: usize,
     seed: u64,
-    u256_gen_f: F,
 ) -> impl Iterator<Item = TestInsertValEntry> {
+    gen_n_random_trie_value_entries_common(
+        n,
+        seed,
+        gen_variable_nibbles_even_padded_nibbles,
+        gen_rand_u256_bytes,
+    )
+}
+
+fn gen_n_random_trie_value_entries_common<
+    T,
+    K: Fn(&mut StdRng) -> Nibbles,
+    V: Fn(&mut StdRng) -> T,
+>(
+    n: usize,
+    seed: u64,
+    key_gen_f: K,
+    val_gen_f: V,
+) -> impl Iterator<Item = TestInsertEntry<T>> {
     let mut rng = StdRng::seed_from_u64(seed);
-    (0..n).map(move |i| (u256_gen_f(&mut rng), i.to_be_bytes().to_vec()))
+    (0..n).map(move |_| (key_gen_f(&mut rng), val_gen_f(&mut rng)))
 }
 
 pub(crate) fn generate_n_hash_nodes_entries_for_empty_slots_in_trie<N: PartialTrie>(
@@ -115,6 +135,16 @@ pub(crate) fn generate_n_hash_nodes_entries_for_empty_slots_in_trie<N: PartialTr
         .into_iter()
         .map(|k| (k, rng.gen()))
         .collect()
+}
+
+pub(crate) fn create_trie_with_random_variable_key_entries<T: PartialTrie>(
+    n: usize,
+    seed: u64,
+) -> T {
+    let mut trie = T::default();
+    trie.extend(generate_n_random_variable_trie_value_entries(n, seed));
+
+    trie
 }
 
 fn gen_fixed_nibbles(rng: &mut StdRng) -> Nibbles {
@@ -144,7 +174,6 @@ fn gen_variable_nibbles(rng: &mut StdRng) -> Nibbles {
 
     U256::from_little_endian(&bytes).into()
 }
-
 // TODO: Replace with `PartialTrie` `iter` methods once done...
 pub(crate) fn get_non_hash_values_in_trie<N: PartialTrie>(
     trie: &Node<N>,
@@ -160,4 +189,46 @@ pub(crate) fn unwrap_iter_item_to_val(item: ValOrHash) -> Vec<u8> {
         ValOrHash::Val(v) => v,
         ValOrHash::Hash(_) => unreachable!(),
     }
+}
+
+fn gen_rand_u256_bytes(rng: &mut StdRng) -> Vec<u8> {
+    let num_bytes = 256 / 8;
+
+    let mut buf = Vec::with_capacity(num_bytes);
+    buf.resize(num_bytes, 0);
+    rng.fill_bytes(&mut buf);
+
+    buf
+}
+
+/// Initializes a trie with keys large enough to force hashing (nodes less than
+/// 32 bytes are not hashed).
+pub(crate) fn create_trie_with_large_entry_nodes<T: Into<Nibbles> + Copy>(keys: &[T]) -> TrieType {
+    let mut trie = TrieType::default();
+    for (k, v) in keys.iter().map(|k| (*k).into()).map(large_entry) {
+        trie.insert(k, v.clone());
+    }
+
+    trie
+}
+
+pub(crate) fn handmade_trie_1() -> (TrieType, Vec<Nibbles>) {
+    let ks = vec![0x1234, 0x1324, 0x132400005_u64, 0x2001, 0x2002];
+    let ks_nibbles: Vec<Nibbles> = ks.into_iter().map(|k| k.into()).collect();
+    let trie = create_trie_with_large_entry_nodes(&ks_nibbles);
+
+    // Branch (0x)  --> 1, 2
+    // Branch (0x1) --> 2, 3
+    // Leaf (0x1234) --> (n: 0x34, v: [0])
+
+    // Extension (0x13) --> n: 0x24
+    // Branch (0x1324, v: [1]) --> 0
+    // Leaf (0x132400005) --> (0x0005, v: [2])
+
+    // Extension (0x2) --> n: 0x00
+    // Branch (0x200) --> 1, 2
+    // Leaf  (0x2001) --> (n: 0x1, v: [3])
+    // Leaf  (0x2002) --> (n: 0x2, v: [4])
+
+    (trie, ks_nibbles)
 }

--- a/src/trie_hashing.rs
+++ b/src/trie_hashing.rs
@@ -108,9 +108,9 @@ mod tests {
         nibbles::{Nibble, Nibbles},
         partial_trie::{HashedPartialTrie, Node, PartialTrie, WrappedNode},
         testing_utils::{
-            common_setup, entry, generate_n_random_fixed_even_nibble_padded_trie_entries,
-            generate_n_random_fixed_trie_entries, generate_n_random_variable_keys, large_entry,
-            TestInsertValEntry,
+            common_setup, entry, generate_n_random_fixed_even_nibble_padded_trie_value_entries,
+            generate_n_random_fixed_trie_value_entries,
+            generate_n_random_variable_trie_value_entries, large_entry, TestInsertValEntry,
         },
         trie_hashing::hash_bytes,
     };
@@ -306,8 +306,11 @@ mod tests {
     fn massive_random_data_insert_fixed_keys_hashes_agree_with_eth_trie() {
         common_setup();
         insert_entries_into_our_and_lib_tries_and_assert_equal_hashes(
-            &generate_n_random_fixed_trie_entries(NUM_INSERTS_FOR_ETH_TRIE_CRATE_MASSIVE_TEST, 0)
-                .collect::<Vec<_>>(),
+            &generate_n_random_fixed_trie_value_entries(
+                NUM_INSERTS_FOR_ETH_TRIE_CRATE_MASSIVE_TEST,
+                0,
+            )
+            .collect::<Vec<_>>(),
         );
     }
 
@@ -315,7 +318,7 @@ mod tests {
     fn massive_random_data_insert_variable_keys_hashes_agree_with_eth_trie() {
         common_setup();
         insert_entries_into_our_and_lib_tries_and_assert_equal_hashes(
-            &generate_n_random_fixed_even_nibble_padded_trie_entries(
+            &generate_n_random_fixed_even_nibble_padded_trie_value_entries(
                 NUM_INSERTS_FOR_ETH_TRIE_CRATE_MASSIVE_TEST,
                 0,
             )
@@ -357,7 +360,7 @@ mod tests {
     fn massive_trie_data_deletion_agrees_with_eth_trie() {
         common_setup();
 
-        let entries: Vec<_> = generate_n_random_fixed_even_nibble_padded_trie_entries(
+        let entries: Vec<_> = generate_n_random_fixed_even_nibble_padded_trie_value_entries(
             NUM_INSERTS_FOR_ETH_TRIE_CRATE_MASSIVE_TEST,
             8,
         )
@@ -412,15 +415,17 @@ mod tests {
     #[test]
     fn replacing_part_of_a_trie_with_a_hash_node_produces_same_hash() {
         let entries = (0..16).flat_map(|i| {
-            generate_n_random_variable_keys(NODES_PER_BRANCH_FOR_HASH_REPLACEMENT_TEST, i).map(
-                move |(mut k, v)| {
-                    // Force all keys to be under a given branch at root.
-                    k.truncate_n_nibbles_front_mut(1);
-                    k.push_nibble_front(i as Nibble);
-
-                    (k, v)
-                },
+            generate_n_random_variable_trie_value_entries(
+                NODES_PER_BRANCH_FOR_HASH_REPLACEMENT_TEST,
+                i,
             )
+            .map(move |(mut k, v)| {
+                // Force all keys to be under a given branch at root.
+                k.truncate_n_nibbles_front_mut(1);
+                k.push_nibble_front(i as Nibble);
+
+                (k, v)
+            })
         });
 
         let mut trie = HashedPartialTrie::from_iter(entries);

--- a/src/trie_ops.rs
+++ b/src/trie_ops.rs
@@ -778,8 +778,9 @@ mod tests {
         testing_utils::{
             common_setup, entry, entry_with_value,
             generate_n_hash_nodes_entries_for_empty_slots_in_trie,
-            generate_n_random_fixed_trie_entries, generate_n_random_variable_keys,
-            get_non_hash_values_in_trie, unwrap_iter_item_to_val, TestInsertValEntry,
+            generate_n_random_fixed_trie_value_entries,
+            generate_n_random_variable_trie_value_entries, get_non_hash_values_in_trie,
+            unwrap_iter_item_to_val, TestInsertValEntry,
         },
         utils::create_mask_of_1s,
     };
@@ -877,7 +878,8 @@ mod tests {
     #[test]
     fn mass_inserts_fixed_sized_keys_all_entries_are_retrievable() {
         common_setup();
-        let entries: Vec<_> = generate_n_random_fixed_trie_entries(MASSIVE_TRIE_SIZE, 0).collect();
+        let entries: Vec<_> =
+            generate_n_random_fixed_trie_value_entries(MASSIVE_TRIE_SIZE, 0).collect();
 
         insert_entries_and_assert_all_exist_in_trie_with_no_extra(&entries);
     }
@@ -885,7 +887,8 @@ mod tests {
     #[test]
     fn mass_inserts_variable_sized_keys_all_entries_are_retrievable() {
         common_setup();
-        let entries: Vec<_> = generate_n_random_variable_keys(MASSIVE_TRIE_SIZE, 0).collect();
+        let entries: Vec<_> =
+            generate_n_random_variable_trie_value_entries(MASSIVE_TRIE_SIZE, 0).collect();
 
         insert_entries_and_assert_all_exist_in_trie_with_no_extra(&entries);
     }
@@ -894,7 +897,7 @@ mod tests {
     fn mass_inserts_variable_sized_keys_with_hash_nodes_all_entries_are_retrievable() {
         common_setup();
         let non_hash_entries: Vec<_> =
-            generate_n_random_variable_keys(MASSIVE_TRIE_SIZE, 0).collect();
+            generate_n_random_variable_trie_value_entries(MASSIVE_TRIE_SIZE, 0).collect();
         let mut trie = StandardTrie::from_iter(non_hash_entries.iter().cloned());
 
         let extra_hash_entries = generate_n_hash_nodes_entries_for_empty_slots_in_trie(
@@ -925,11 +928,11 @@ mod tests {
             StandardTrie::new(Node::Empty)
         );
 
-        let entries = generate_n_random_fixed_trie_entries(MASSIVE_TRIE_SIZE, 0);
+        let entries = generate_n_random_fixed_trie_value_entries(MASSIVE_TRIE_SIZE, 0);
         let big_trie_1 = StandardTrie::from_iter(entries);
         assert_eq!(big_trie_1, big_trie_1);
 
-        let entries = generate_n_random_fixed_trie_entries(MASSIVE_TRIE_SIZE, 1);
+        let entries = generate_n_random_fixed_trie_value_entries(MASSIVE_TRIE_SIZE, 1);
         let big_trie_2 = StandardTrie::from_iter(entries);
 
         assert_ne!(big_trie_1, big_trie_2)
@@ -951,7 +954,7 @@ mod tests {
         common_setup();
 
         let random_entries: Vec<_> =
-            generate_n_random_fixed_trie_entries(MASSIVE_TRIE_SIZE, 9001).collect();
+            generate_n_random_fixed_trie_value_entries(MASSIVE_TRIE_SIZE, 9001).collect();
         let trie = StandardTrie::from_iter(random_entries.iter().cloned());
 
         for (k, v) in random_entries.into_iter() {
@@ -966,7 +969,7 @@ mod tests {
     fn held_trie_cow_references_do_not_change_as_trie_changes() {
         common_setup();
 
-        let entries = generate_n_random_variable_keys(COW_TEST_TRIE_SIZE, 9002);
+        let entries = generate_n_random_variable_trie_value_entries(COW_TEST_TRIE_SIZE, 9002);
 
         let mut all_nodes_in_trie_after_each_insert = Vec::new();
         let mut root_node_after_each_insert = Vec::new();
@@ -993,7 +996,7 @@ mod tests {
         common_setup();
 
         let entries: HashSet<_> =
-            generate_n_random_variable_keys(MASSIVE_TRIE_SIZE, 9003).collect();
+            generate_n_random_variable_trie_value_entries(MASSIVE_TRIE_SIZE, 9003).collect();
         let trie = StandardTrie::from_iter(entries.iter().cloned());
 
         let trie_items: HashSet<_> = trie
@@ -1027,7 +1030,8 @@ mod tests {
     fn deletion_massive_trie() {
         common_setup();
 
-        let entries: Vec<_> = generate_n_random_variable_keys(MASSIVE_TRIE_SIZE, 7).collect();
+        let entries: Vec<_> =
+            generate_n_random_variable_trie_value_entries(MASSIVE_TRIE_SIZE, 7).collect();
         let mut trie = StandardTrie::from_iter(entries.iter().cloned());
 
         // Delete half of the elements


### PR DESCRIPTION
A bit more tooling related to extracting stats from tries. Primary use case that I want from this is to compare sub-tries from the base trie they were created from.

To give an idea of what the output looks like:
```
Trie Stats: (local_partial_plus_delta_storage_txn_4.json)
Counts:
Empty: 39 (18.660%)
Hash: 154 (73.684%)
Branch: 13 (6.220%)
Extension: 0 (0.000%)
Leaf: 3 (1.435%)

Depth stats:
Lowest depth: 4
Average leaf depth: 4.000
Average hash depth: 2.604

Trie Stats: (local_full_post_delta_storage_txn_4.json)
Counts:
Empty: 50 (19.455%)
Hash: 164 (63.813%)
Branch: 16 (6.226%)
Extension: 0 (0.000%)
Leaf: 27 (10.506%)

Depth stats:
Lowest depth: 4
Average leaf depth: 4.000
Average hash depth: 2.433

Node comparison: Total nodes: 209 / 257 (81.323%)
Non-empty: 170 / 207 (82.126%)
Total empty: 39 / 50 (78.000%)
Total hash: 154 / 164 (93.902%)
Total branch: 13 / 16 (81.250%)
Total extension: 0 / 0 (NaN%)
Total leaf: 3 / 27 (11.111%)

Depth comparison: Lowest depth: 4 / 4 (100.000%)
Avg leaf depth: 4.000 / 4.000 (100.000%)
Avg hash depth: 2.604 / 2.433 (107.027%)
```